### PR TITLE
Fix typo in multimethods post: (struct-out vec)

### DIFF
--- a/_src/posts/2016-02-18-simple-safe-multimethods-in-racket.md
+++ b/_src/posts/2016-02-18-simple-safe-multimethods-in-racket.md
@@ -35,7 +35,7 @@ This blog post is somewhat long and technical, so before proceeding any further,
 
 (provide mul
          (struct-out num)
-         (struct-out vals))
+         (struct-out vec))
 
 (struct num (val))
 (struct vec (vals))
@@ -92,7 +92,7 @@ What exactly is this dangerous-sounding “spooky action”, and what causes it?
 ```racket
 (provide mul
          (struct-out num)
-         (struct-out vals))
+         (struct-out vec))
 
 (struct num (val))
 (struct vec (vals))


### PR DESCRIPTION
The `(struct-out vals)` should be `(struct-out vec)`.
