### PR TITLE
Import Identity to show where it comes from

### DIFF
--- a/_src/posts/2016-10-01-using-types-to-unit-test-in-haskell.md
+++ b/_src/posts/2016-10-01-using-types-to-unit-test-in-haskell.md
@@ -113,6 +113,8 @@ Of course, this blog post is about testing, so we’re going to go further and t
 Given that we now have functions depending on an interface instead of `IO`, we can create separate instances of our typeclasses for use in tests. Let’s start with the `renderUserProfile` function. We’ll create a simple wrapper around the `Identity` type, since we don’t actually care much about the “effects” of our `MonadDB` methods:
 
 ```haskell
+import Data.Functor.Identity
+
 newtype TestM a = TestM (Identity a)
   deriving (Functor, Applicative, Monad)
 


### PR DESCRIPTION
It took my inexperienced self a little while to work out where Identity came from. I'm ok with Functors, Applicatives, Monads etc, but I didn't know where `Identity` came from. I added an import to make this obvious in the blog post.

Thanks for the excellent content!